### PR TITLE
Feat: change git config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           cd publish || exit 1
           git init
-          git config --local user.name "actions"
-          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b release
           git add geoip.dat geoip.dat.sha256sum *.gz *.zip
           git commit -m "${{ env.RELEASE_NAME }}"


### PR DESCRIPTION
Using github-actions for pushing assets to "release" branch

According to the [discussions](https://github.community/t/github-actions-bot-email-address/17204/5), the email for github-actions is `[user-id]+[user-name]@users.noreply.github.com` . It's also worked for personal private email address(with the same rule)    

The `[user-id]` for [github-actions](https://github.com/features/actions) could be found [here](https://api.github.com/users/github-actions%5Bbot%5D). Replace the `[user-name]` with your own to get your own `[user-id]`.

The following is a test I did. Test repo [here](https://github.com/yin1999/test)

![image](https://user-images.githubusercontent.com/15844309/111726462-f9fbaf00-88a3-11eb-86a0-2d07bed0d2ae.png)
