### PR TITLE
Add prefixes blocked in Russia

### DIFF
--- a/config.json
+++ b/config.json
@@ -165,6 +165,30 @@
           "twitter": ["AS8945", "AS63179", "AS54888", "AS35995", "AS13414"]
         }
       }
+    },    
+    {
+      "type": "text",
+      "action": "add",
+      "args": {
+        "name": "ru-antifilter-download",
+        "uri": "https://antifilter.download/list/ipresolve.lst"
+      }
+    },
+    {
+      "type": "text",
+      "action": "add",
+      "args": {
+        "name": "ru-antifilter-download",
+        "uri": "https://antifilter.download/list/subnet.lst"
+      }
+    },
+    {
+      "type": "text",
+      "action": "add",
+      "args": {
+        "name": "ru-antifilter-download-community",
+        "uri": "https://community.antifilter.download/list/community.lst"
+      }
     },
     {
       "type": "private",


### PR DESCRIPTION
Hello! Many people in Russia use v2rayN to bypass blocking, which in turn uses this repository as a source for updating geoip files. So I ask you to approve this pr so we can use dynamically updated geoip database in our rules.

This will only increase geoip.dat file size by about 5%.

A bit of details - antifilter.download publishes data from the registry of blocked domains and ip. community.antifilter.download is a service where the list is generated by the community by voting in telegram bot.

Thank you!