### PR TITLE
add GitHub ip ranges

### DIFF
--- a/config.json
+++ b/config.json
@@ -116,6 +116,28 @@
       }
     },
     {
+      "type": "json",
+      "action": "add",
+      "args": {
+        "name": "github",
+        "uri": "https://api.github.com/meta",
+        "jsonPath": [
+          "hooks",
+          "web",
+          "api",
+          "git",
+          "github_enterprise_importer",
+          "packages",
+          "pages",
+          "importer",
+          "actions",
+          "actions_macos",
+          "codespaces",
+          "copilot"
+        ]
+      }
+    },
+    {
       "type": "maxmindGeoLite2ASNCSV",
       "action": "add",
       "args": {


### PR DESCRIPTION
This pull request adds a new JSON data source configuration for `GitHub` metadata to the `config.json` file. The main change is the inclusion of a new entry that fetches and parses specific fields from the GitHub API.

**Configuration updates:**

* Added a new JSON data source named `github` to `config.json`, which fetches data from `https://api.github.com/meta` and extracts several key fields such as `hooks`, `web`, `api`, `git`, `github_enterprise_importer`, `packages`, `pages`, `importer`, `actions`, `actions_macos`, `codespaces`, and `copilot`.