### PR TITLE
add amazon aws ip ranges

### DIFF
--- a/config.json
+++ b/config.json
@@ -116,6 +116,18 @@
       }
     },
     {
+      "type": "json",
+      "action": "add",
+      "args": {
+        "name": "amazon",
+        "uri": "https://ip-ranges.amazonaws.com/ip-ranges.json",
+        "jsonPath": [
+          "prefixes.#(service==\"AMAZON\")#.ip_prefix",
+          "ipv6_prefixes.#(service==\"AMAZON\")#.ipv6_prefix"
+        ]
+      }
+    },
+    {
       "type": "maxmindGeoLite2ASNCSV",
       "action": "add",
       "args": {


### PR DESCRIPTION
This pull request adds support for fetching and processing ``Amazon's`` IP ranges from their published JSON file. The new configuration entry specifies how to extract both IPv4 and IPv6 prefixes for the "AMAZON" service.

- Integration of Amazon IP ranges:
  * Added a new data source of type `json` named `amazon` in `config.json`, which fetches IP ranges from `https://ip-ranges.amazonaws.com/ip-ranges.json` and extracts both IPv4 and IPv6 prefixes for the "AMAZON" service using the specified `jsonPath` expressions.