### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - ".gitignore"
       - "LICENSE*"
       - "*.md"
+permissions:
+  contents: write
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/Loyalsoldier/geoip/security/code-scanning/2](https://github.com/Loyalsoldier/geoip/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (best here since there is a single job and all steps share the same token needs).  
Use least privilege while preserving behavior:

- `contents: write` is required for:
  - pushing to the `release` branch via git
  - creating GitHub releases via `gh release create`
- No additional scopes are required by shown steps.

Edit **`.github/workflows/build.yml`** by inserting `permissions:` between the trigger section (`on:` …) and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
